### PR TITLE
Fix table2 data loss when saving without reading string fields

### DIFF
--- a/dist/strategies/common/table/FranchiseTableStrategy.d.ts.map
+++ b/dist/strategies/common/table/FranchiseTableStrategy.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"FranchiseTableStrategy.d.ts","sourceRoot":"","sources":["../../../../src/strategies/common/table/FranchiseTableStrategy.js"],"names":[],"mappings":";;IACA,+EAkCC;IACD,wCAEC;IACD,iEAyBC;IACD,+DAyBC"}
+{"version":3,"file":"FranchiseTableStrategy.d.ts","sourceRoot":"","sources":["../../../../src/strategies/common/table/FranchiseTableStrategy.js"],"names":[],"mappings":";;IACA,+EAqCC;IACD,wCAEC;IACD,iEAyBC;IACD,+DAyBC"}

--- a/src/strategies/common/table/FranchiseTableStrategy.js
+++ b/src/strategies/common/table/FranchiseTableStrategy.js
@@ -31,6 +31,9 @@ FranchiseTableStrategy.getTable2BinaryData = (
     }
     if (table2Records.length > 0) {
         table2Data.push(fullTable2Buffer.slice(currentOffset));
+    } else {
+        // No string fields were read, preserve original table2 data entirely
+        table2Data.push(fullTable2Buffer);
     }
     return table2Data;
 };

--- a/tests/unit/strategies/common/FranchiseTableStrategy.spec.js
+++ b/tests/unit/strategies/common/FranchiseTableStrategy.spec.js
@@ -90,6 +90,41 @@ describe('Franchise Table Strategy unit tests', () => {
             common.hashCompare(Buffer.concat(result), expectedResult);
         });
 
+        it('preserves original table2 buffer when no string fields were read (table2Records is empty)', () => {
+            // This test demonstrates the bug where table2 data is lost when
+            // no string fields are read before saving. This happens when
+            // modifying only non-string fields (like cap penalties).
+            //
+            // Bug scenario:
+            // 1. Open a franchise file
+            // 2. Read only non-string fields (e.g., TeamIndex, ThisYearCapPenalties)
+            // 3. Modify those fields and save
+            // 4. Re-open the file - string fields return BitView objects instead of strings
+            //
+            // Root cause: When table2Records.length === 0, the function returned
+            // an empty array, losing the original table2 data. On reload,
+            // tableTotalLength equals table1Length, so hasSecondTable becomes false,
+            // and string fields fall through to return raw BitView objects.
+
+            const table2Records = []; // No string fields were read
+
+            const originalTable2Buffer = Buffer.from([
+                0x34, 0x39, 0x65, 0x72, 0x73, 0x00, // "49ers\0"
+                0x42, 0x65, 0x61, 0x72, 0x73, 0x00, // "Bears\0"
+                0x50, 0x61, 0x63, 0x6b, 0x65, 0x72, 0x73, 0x00 // "Packers\0"
+            ]);
+
+            const result = FranchiseTableStrategy.getTable2BinaryData(
+                table2Records,
+                originalTable2Buffer
+            );
+
+            // The original table2 buffer should be preserved, not lost
+            const combinedResult = Buffer.concat(result);
+            expect(combinedResult.length).to.be.greaterThan(0);
+            common.hashCompare(combinedResult, originalTable2Buffer);
+        });
+
         // it('performance test', () => {
         //     let table2RecordsPerformanceTest = [];
 


### PR DESCRIPTION
When modifying and saving a franchise file without reading any string fields, the getTable2BinaryData() function returned an empty array, causing the original table2 buffer to be lost. On reload, tableTotalLength equals table1Length, hasSecondTable becomes false, and string fields return raw BitView objects instead of parsed strings.

This commit adds an else clause to preserve the original table2 buffer when table2Records is empty.

Includes a unit test that demonstrates the bug scenario. Confirmed that the unit test demonstrates the problem before the fix, confirmed it passes after the fix.