### PR TITLE
Fixed issue causing table2 data loss with non-UTF8 characters

### DIFF
--- a/src/strategies/common/table2Field/FranchiseTable2FieldStrategy.js
+++ b/src/strategies/common/table2Field/FranchiseTable2FieldStrategy.js
@@ -15,9 +15,8 @@ FranchiseTable2FieldStrategy.setUnformattedValueFromFormatted = (
         valueBuffer = valueBuffer.subarray(0, maxLength);
     }
     const numberOfNullCharactersToAdd = maxLength - valueBuffer.length;
-    for (let i = 0; i < numberOfNullCharactersToAdd; i++) {
-        valueBuffer = Buffer.concat([valueBuffer, Buffer.from([0])]);
-    }
+    const padBuffer = Buffer.alloc(numberOfNullCharactersToAdd, 0);
+    valueBuffer = Buffer.concat([valueBuffer, padBuffer]);
     return valueBuffer;
 };
 export default FranchiseTable2FieldStrategy;

--- a/src/strategies/common/table2Field/FranchiseTable2FieldStrategy.js
+++ b/src/strategies/common/table2Field/FranchiseTable2FieldStrategy.js
@@ -9,14 +9,15 @@ FranchiseTable2FieldStrategy.setUnformattedValueFromFormatted = (
     formattedValue,
     maxLength
 ) => {
-    let valuePadded = formattedValue;
-    if (valuePadded.length > maxLength) {
-        valuePadded = valuePadded.substring(0, maxLength);
+    // Convert formatted value to buffer first to ensure accurate length
+    let valueBuffer = Buffer.from(formattedValue);
+    if (valueBuffer.length > maxLength) {
+        valueBuffer = valueBuffer.subarray(0, maxLength);
     }
-    const numberOfNullCharactersToAdd = maxLength - formattedValue.length;
+    const numberOfNullCharactersToAdd = maxLength - valueBuffer.length;
     for (let i = 0; i < numberOfNullCharactersToAdd; i++) {
-        valuePadded += String.fromCharCode(0);
+        valueBuffer = Buffer.concat([valueBuffer, Buffer.from([0])]);
     }
-    return Buffer.from(valuePadded);
+    return valueBuffer;
 };
 export default FranchiseTable2FieldStrategy;

--- a/tests/e2e/m26.spec.js
+++ b/tests/e2e/m26.spec.js
@@ -193,6 +193,49 @@ describe('Madden 26 end to end tests', function () {
                 });
             });
 
+            it('can save a table2 field containing a non-utf8 character without data loss', (done) => {
+                let table = file.getTableByName('TeamSetting');
+                console.time('read records 1');
+
+                table.readRecords('MaxCloudReplaysDescription').then(() => {
+                    console.timeEnd('read records 1');
+                    
+                    const originalValue = table.records[0].MaxCloudReplaysDescription;
+                    const modifiedValue = originalValue.replace('Cloud', 'Dloud');
+
+                    console.time('set value');
+                    table.records[0].MaxCloudReplaysDescription = modifiedValue;
+                    console.timeEnd('set value');
+
+                    console.time('actual save call');
+
+                    file.save(filePathToSave).then(() => {
+                        console.timeEnd('actual save call');
+                        console.time('read file');
+                        let file2 = new FranchiseFile(filePathToSave);
+
+                        file2.on('ready', () => {
+                            console.timeEnd('read file');
+                            let table2 = file2.getTableByName('TeamSetting');
+                            console.time('read records 2');
+
+                            table2.readRecords('MaxCloudReplaysDescription').then(() => {
+                                console.timeEnd('read records 2');
+                                expect(table2.records[0].MaxCloudReplaysDescription).to.equal(
+                                    modifiedValue
+                                );
+
+                                // Ensure adjacent table2 field hasn't been impacted
+                                expect(table2.records[1].MaxCloudReplaysDescription).to.equal(
+                                    originalValue
+                                );
+                                done();
+                            });
+                        });
+                    });
+                });
+            });
+
             it('can save a table2 field and a normal field together', (done) => {
                 let division = file.getTableByName('Division');
                 let popularityComponentTable = file.getTableByName(


### PR DESCRIPTION
Issue: 
- When editing a table2 field containing non-UTF8 characters, table2 data often became garbled/truncated, even in records not edited.

Cause:
- API calculates padding byte length to add for table2 field's unformattedValue based on length of formattedValue string
- This only works under the assumption that the length of the string is equal to its byte length
- With non-UTF8 characters, the byte length becomes longer than the string length due to the character(s) occupying multiple bytes
- Thus, the actual amount of padding needed is less than the calculated amount, causing the incorrectly padded unformattedValue to exceed the maxLength of the table2 field and spill over into adjacent data, leading to lost data in adjacent fields

Solution:
- Updated the table2 field strategy to first convert the formattedValue string to a buffer, then use that buffer for all subsequent length/padding calculations. This ensures the padding length always matches up with the byte length of the string, even if that byte length is greater than the string length
- Added test case in M26 e2e tests file to verify fix, and verified no regressions, as all other tests are passing
