### PR TITLE
Improved table2 string writing/truncation

### DIFF
--- a/src/strategies/common/table2Field/FranchiseTable2FieldStrategy.js
+++ b/src/strategies/common/table2Field/FranchiseTable2FieldStrategy.js
@@ -9,14 +9,10 @@ FranchiseTable2FieldStrategy.setUnformattedValueFromFormatted = (
     formattedValue,
     maxLength
 ) => {
-    // Convert formatted value to buffer first to ensure accurate length
-    let valueBuffer = Buffer.from(formattedValue);
-    if (valueBuffer.length > maxLength) {
-        valueBuffer = valueBuffer.subarray(0, maxLength);
-    }
-    const numberOfNullCharactersToAdd = maxLength - valueBuffer.length;
-    const padBuffer = Buffer.alloc(numberOfNullCharactersToAdd, 0);
-    valueBuffer = Buffer.concat([valueBuffer, padBuffer]);
+    // We can simply allocate a buffer of maxLength size and then use
+    // buffer.write, which automatically handles UTF-8 and truncation
+    let valueBuffer = Buffer.alloc(maxLength, 0);
+    valueBuffer.write(formattedValue, 0, maxLength, 'utf-8');
     return valueBuffer;
 };
 export default FranchiseTable2FieldStrategy;

--- a/tests/e2e/m26.spec.js
+++ b/tests/e2e/m26.spec.js
@@ -244,6 +244,38 @@ describe('Madden 26 end to end tests', function () {
                 });
             });
 
+            it('can save a table2 field ending with a non-utf8 character with complete truncation', (done) => {
+                let table = file.getTableByName('Player');
+                console.time('read records 1');
+                table.readRecords(['LastName']).then(() => {
+                    console.timeEnd('read records 1');
+                    console.time('set value');
+                    table.records[20].LastName = 'Allen™™™™™™™™™™™™™™™™™™™™™™™™™™™™™™™™™™™™™™™™™™';
+                    console.timeEnd('set value');
+
+                    console.time('actual save call');
+                    file.save(filePathToSave).then(() => {
+                        console.timeEnd('actual save call');
+                        console.time('read file');
+                        let file2 = new FranchiseFile(filePathToSave);
+
+                        file2.on('ready', () => {
+                            console.timeEnd('read file');
+                            let table2 = file2.getTableByName('Player');
+                            console.time('read records 2');
+
+                            table2.readRecords(['LastName']).then(() => {
+                                console.timeEnd('read records 2');
+                                expect(table2.records[20].LastName).to.equal(
+                                    'Allen™™™™™'
+                                );
+                                done();
+                            });
+                        });
+                    });
+                });
+            });
+
             it('can save a table2 field and a normal field together', (done) => {
                 let division = file.getTableByName('Division');
                 let popularityComponentTable = file.getTableByName(


### PR DESCRIPTION
- table2 strings that ended with non-UTF8 characters (ex: ™) and exceeded the max length for the field for being cut off improperly without consideration for these characters being multi-byte, leading to weird garbled characters like pictured with the question mark character in the last name here:
<img width="1044" height="557" alt="image" src="https://github.com/user-attachments/assets/e3038593-0248-49cc-ba3b-f1935a13524e" />

- Fixed this by refactoring the table2 strategy to first use `Buffer.alloc()` to allocate a new null filled buffer of maxLength size, and then use ``Buffer.write()`` to write the string into the buffer, which automatically handles truncation. This both simplifies the code (as there's now no need to separately calculate padding length and add it on to the buffer) and fixes this truncation issue.

- Added a test case for this scenario and verified it passes after the fix